### PR TITLE
Add missing volume mounts

### DIFF
--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -330,8 +330,8 @@ type RendezvousServerConfig struct {
 }
 
 func (c *RendezvousServerConfig) setValues(s *fdov1alpha1.FDORendezvousServer) error {
-	c.StorageDriver = NewDriver("/etc/fdo/rendezvous_registered/")
-	c.SessionStoreDriver = NewDriver("/etc/fdo/rendezvous_sessions/")
+	c.StorageDriver = NewDriver("/etc/fdo/registered/")
+	c.SessionStoreDriver = NewDriver("/etc/fdo/sessions/")
 	c.TrustedManufacturerKeysPath = "/etc/fdo/keys/manufacturer_cert.pem"
 	c.Bind = "0.0.0.0:8082"
 	return nil

--- a/controllers/fdomanufacturingserver_controller.go
+++ b/controllers/fdomanufacturingserver_controller.go
@@ -195,6 +195,11 @@ func (r *FDOManufacturingServerReconciler) createOrUpdateDeployment(log logr.Log
 								SubPath:   "device_ca_cert.pem",
 								ReadOnly:  true,
 							},
+							{
+								Name:      "sessions",
+								MountPath: "/etc/fdo/sessions",
+								ReadOnly:  false,
+							},
 						},
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: &privilegeEscalation,
@@ -327,6 +332,12 @@ func (r *FDOManufacturingServerReconciler) createOrUpdateDeployment(log logr.Log
 								},
 								Optional: &optional,
 							},
+						},
+					},
+					{
+						Name: "sessions",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
 					},
 				},

--- a/controllers/fdoonboardingserver_controller.go
+++ b/controllers/fdoonboardingserver_controller.go
@@ -275,6 +275,18 @@ func (r *FDOOnboardingServerReconciler) createOrUpdateDeployment(log logr.Logger
 					},
 				},
 			},
+			{
+				Name: "sessions",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: "device-specific-serviceinfo",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
 		}
 
 		for _, f := range files {
@@ -335,6 +347,16 @@ func (r *FDOOnboardingServerReconciler) createOrUpdateDeployment(log logr.Logger
 								MountPath: "/etc/fdo/keys/device_ca_cert.pem",
 								SubPath:   "device_ca_cert.pem",
 								ReadOnly:  true,
+							},
+							{
+								Name:      "sessions",
+								MountPath: "/etc/fdo/sessions",
+								ReadOnly:  false,
+							},
+							{
+								Name:      "device-specific-serviceinfo",
+								MountPath: "/etc/fdo/keys/device_specific_serviceinfo",
+								ReadOnly:  false,
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{

--- a/controllers/fdorendezvousserver_controller.go
+++ b/controllers/fdorendezvousserver_controller.go
@@ -157,6 +157,16 @@ func (r *FDORendezvousServerReconciler) createOrUpdateDeployment(log logr.Logger
 								SubPath:   "manufacturer_cert.pem",
 								ReadOnly:  true,
 							},
+							{
+								Name:      "registered",
+								MountPath: "/etc/fdo/registered",
+								ReadOnly:  false,
+							},
+							{
+								Name:      "sessions",
+								MountPath: "/etc/fdo/sessions",
+								ReadOnly:  false,
+							},
 						},
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: &privilegeEscalation,
@@ -192,6 +202,18 @@ func (r *FDORendezvousServerReconciler) createOrUpdateDeployment(log logr.Logger
 								},
 								Optional: &optional,
 							},
+						},
+					},
+					{
+						Name: "registered",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "sessions",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
 					},
 				},


### PR DESCRIPTION
Add volume mounts (empty directory for now) according to the generated server configuration. This makes the operator independent of whether the directories actually exist inside the container images for FDO servers.

This should solve the server-side part of issue #118 when using `quay.io/fido-fdo` images.